### PR TITLE
in combine.py enable savefig for service canvas 1, and clarify figpaths

### DIFF
--- a/python/combine.py
+++ b/python/combine.py
@@ -498,6 +498,15 @@ def process_run(meta, objname, input_mvm, fullpath_rwa, fullpath_dta, columns_rw
     ax.set_xlabel("Time [sec]")
     ax.legend(loc='upper center', ncol=2)
 
+    ax.set_title ("Test n %s"%meta[objname]['test_name'], weight='heavy')
+    figpath = "%s/%s_service_%s.pdf" % (output_directory, meta[objname]['Campaign'],  objname.replace('.txt', ''))
+    print(f'Saving figure to {figpath}')
+    plt.savefig(figpath)
+
+
+    ####################################################
+    '''general service canavas number 2, measured simulation parameters'''
+    ####################################################
 
     figbis = plt.figure()
     figbis.suptitle ("Test n %s"%meta[objname]['test_name'], weight='heavy')
@@ -506,9 +515,6 @@ def process_run(meta, objname, input_mvm, fullpath_rwa, fullpath_dta, columns_rw
     axbis0 = figbis.add_subplot(gs[0, 0])
     axbis1 = figbis.add_subplot(gs[0, 1])
     axbis2 = figbis.add_subplot(gs[1:, :])
-    ####################################################
-    '''general service canavas number 2, measured simulation parameters'''
-    ####################################################
 
     df.plot(ax=axbis2, x='dt', y='airway_pressure', label='airway_pressure [cmH2O]', c=colors['sim_airway_pressure'])
     df.plot(ax=axbis2, x='dt', y='total_flow',    label='total_flow      [l/min]', c=colors['total_flow'])
@@ -536,7 +542,7 @@ def process_run(meta, objname, input_mvm, fullpath_rwa, fullpath_dta, columns_rw
     axbis1.hist ( dfhd[( dfhd['resistance']>0)]['resistance'].unique() , bins=50 )
     axbis1.set_xlabel("Measured resistance [cmH2O/l/s]")
 
-    figpath = "%s/%s_service_%s.pdf" % (output_directory, meta[objname]['Campaign'],  objname.replace('.txt', '')) # TODO: make sure it is correct, or will overwrite!
+    figpath = "%s/%s_service2_%s.pdf" % (output_directory, meta[objname]['Campaign'],  objname.replace('.txt', '')) # TODO: make sure it is correct, or will overwrite!
     print(f'Saving figure to {figpath}')
     figbis.savefig(figpath)
 
@@ -620,7 +626,7 @@ def process_run(meta, objname, input_mvm, fullpath_rwa, fullpath_dta, columns_rw
       dftmp.plot(ax=ax11, x='dt', y='compliance',   label='SIM compliance', c='black')
       dftmp.plot(ax=ax11, x='dt', y='airway_resistance',   label='SIM resistance', c='black', linestyle="--")
 
-      figpath = "%s/%s_service2_%s.pdf" % (output_directory, meta[objname]['Campaign'],  objname.replace('.txt', '')) # TODO: make sure it is correct, or will overwrite!
+      figpath = "%s/%s_extrainfo_%s.pdf" % (output_directory, meta[objname]['Campaign'],  objname.replace('.txt', '')) # TODO: make sure it is correct, or will overwrite!
       ax11.legend(loc='upper center', ncol=2)
       fig11.savefig(figpath)
       '''

--- a/python/combine.py
+++ b/python/combine.py
@@ -499,7 +499,7 @@ def process_run(meta, objname, input_mvm, fullpath_rwa, fullpath_dta, columns_rw
     ax.legend(loc='upper center', ncol=2)
 
     ax.set_title ("Test n %s"%meta[objname]['test_name'], weight='heavy')
-    figpath = "%s/%s_service_%s.pdf" % (output_directory, meta[objname]['Campaign'],  objname.replace('.txt', ''))
+    figpath = "%s/%s_service_%s.png" % (output_directory, meta[objname]['Campaign'],  objname.replace('.txt', ''))
     print(f'Saving figure to {figpath}')
     plt.savefig(figpath)
 
@@ -542,7 +542,7 @@ def process_run(meta, objname, input_mvm, fullpath_rwa, fullpath_dta, columns_rw
     axbis1.hist ( dfhd[( dfhd['resistance']>0)]['resistance'].unique() , bins=50 )
     axbis1.set_xlabel("Measured resistance [cmH2O/l/s]")
 
-    figpath = "%s/%s_service2_%s.pdf" % (output_directory, meta[objname]['Campaign'],  objname.replace('.txt', '')) # TODO: make sure it is correct, or will overwrite!
+    figpath = "%s/%s_service2_%s.png" % (output_directory, meta[objname]['Campaign'],  objname.replace('.txt', '')) # TODO: make sure it is correct, or will overwrite!
     print(f'Saving figure to {figpath}')
     figbis.savefig(figpath)
 


### PR DESCRIPTION
This enables savefig for service canvas 1, and clarifies figure paths as follows
"%s/%s_service_%s.png" for service canvas 1
"%s/%s_service2_%s.png" for service canvas 2
"%s/%s_extrainfo_%s.pdf" for the commented out version of figure 11 with extra information
